### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@v3
+      uses: asdf-vm/actions/setup@833d04dfd3c702c45fa5cbccffdf17a526d40ed2 # v3
 
     - name: Install asdf tools
       shell: bash

--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -19,7 +19,7 @@ jobs:
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/setup
       - name: Install ansible role/collection dependencies
         working-directory: ./ansible

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -20,7 +20,7 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/setup
       - name: Check if kubernetes/*/* is not empty
         id: check-kubernetes-directory

--- a/.github/workflows/lint-terraform.yaml
+++ b/.github/workflows/lint-terraform.yaml
@@ -19,7 +19,7 @@ jobs:
   terraform-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/setup
       - name: Lint
         working-directory: ./terraform


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.